### PR TITLE
Reorder table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 
 ## Table of Contents:
 
-- [C#](#c)
 - [C/C++](#cc)
+- [C#](#c)
 - [Clojure](#clojure)
 - [Elixir](#elixir)
 - [Erlang](#erlang)


### PR DESCRIPTION
## Description
Puts C/C++ before C# in table of contents

## Motivation and Context
C/C++ appears before C# in the body, but C# appears before C/C++ in the table of contents

## How Has This Been Tested?
Clicked on C/C++ and C# in the table of contents and checked that the browser jumps to the correct section of the document

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Content Update (change which fixes an issue or updates an already existing submission)
- [ ] New Article (change which adds functionality)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have made checks to ensure URLs and other resources are valid
