### PR TITLE
Add tutorial for Jira clone application (Angular)

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,12 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
   - [Introduction to Angular](http://www.discoversdk.com/blog/intro-to-angular-and-the-evolution-of-the-web)
   - [Part 1](http://www.discoversdk.com/blog/angular-5-to-do-list-app-part-1)
 
+- Build a [Jira clone application](https://jira.trungk18.com/) with Angular 9
+  - [Part 1 - Create a new repository and set up a new Angular application with CLI](https://trungk18.com/experience/angular-jira-clone-tutorial-01-planning-and-set-up)
+  - [Part 2 - Build the application layout with flex and TailwindCSS](https://trungk18.com/experience/angular-jira-clone-tutorial-02-application-layout-tailwindcss-flex)
+  - [Part 3 - Setup Akita state management](https://trungk18.com/experience/angular-jira-clone-tutorial-03-akita-state-management)
+  - [Part 4 - Build an editable textbox](https://trungk18.com/experience/angular-jira-clone-tutorial-04-editable-textbox)
+
 #### Node:
 
 - [Build A Simple Website With Node,Express and MongoDB](https://closebrace.com/tutorials/2017-03-02/the-dead-simple-step-by-step-guide-for-front-end-developers-to-getting-up-and-running-with-nodejs-express-and-mongodb)


### PR DESCRIPTION
## Description

I added the tutorial for building a Jira clone application with Angular 9.

See the demo: http://jira.trungk18.com/
Source code: https://github.com/trungk18/jira-clone-angular

## Motivation and Context

I have been working with Angular for about four years. I built cool stuff at Zyllem but almost all of them are internal apps which is difficult to show.

This is a showcase application I've built in my spare time to experiment the new library that I wanted to try before: Akita, TailwindCSS, ng-zorro.

There are many Angular examples on the web but most of them are way too simple. I like to think that this codebase contains enough complexity to offer valuable insights to Angular developers of all skill levels while still being relatively easy to understand.

## How Has This Been Tested?

I see the preview of the README, looks good to me

## Types of changes

- [ ] Content Update (change which fixes an issue or updates an already existing submission)
- [x] New Article (change which adds functionality)
- [ ] Documentation change

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have made checks to ensure URLs and other resources are valid
