### PR TITLE
Fixing it so that C# shows lower than C.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 
 ## Table of Contents:
 
-- [C#](#c)
 - [C/C++](#cc)
+- [C#](#c)
 - [Clojure](#clojure)
 - [Dart](#dart)
 - [Elixir](#elixir)


### PR DESCRIPTION
Adjusting the order since C# is actually shown below C, not the other way around like it was before.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Content Update (change which fixes an issue or updates an already existing submission)
- [x] New Article (change which adds functionality)
- [x] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have made checks to ensure URLs and other resources are valid
