### PR TITLE
Fix typo: Chapter 14 on -> Chapter 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 
 ## C/C++:
 
-- [Build an Interpreter](http://www.craftinginterpreters.com/) (Chapter 14 on is written in C)
+- [Build an Interpreter](http://www.craftinginterpreters.com/) (Chapter 14 is written in C)
 - [Memory Allocators 101 - Write a simple memory allocator](https://arjunsreedharan.org/post/148675821737/memory-allocators-101-write-a-simple-memory)
 - [Write a Shell in C](https://brennan.io/2015/01/16/write-a-shell-in-c/)
 - [Write a FUSE Filesystem](https://www.cs.nmsu.edu/~pfeiffer/fuse-tutorial/)


### PR DESCRIPTION
Simple typo fix in README.md. Changed "Chapter 14 on is written in C" to "Chapter 14 is written in C".