### PR TITLE
Add Apple SwiftUI project tutorial to Swift resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 ## Swift:
 
 - [Hacking with Swift - Learn Swift by doing 39 projects](https://www.hackingwithswift.com/read)
+- [Apple SwiftUI Tutorials (Build Apps by Creating Real Projects)](https://developer.apple.com/tutorials/swiftui)
 - [Retro first-person shooter from scratch](https://github.com/nicklockwood/RetroRampage)
 
 ## Additional Resources


### PR DESCRIPTION
## Summary
- add Apple SwiftUI Tutorials as a project-based Swift learning resource
- keep the existing Swift section structure intact

## Why
This list is for project-based learning. Apple’s SwiftUI tutorial path is hands-on and beginner-friendly, and it complements the current Swift entries.

## Type of change
- documentation/resource list update
