### PR TITLE
Fix broken deep learning tutorial link (Mask detection using PyTorch Lightning)

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 - [Code a Smile Classifier using CNNS in Python](https://github.com/kylemcdonald/SmileCNN)
 - [Natural Language Processing using scikit-learn](https://towardsdatascience.com/natural-language-processing-count-vectorization-with-scikit-learn-e7804269bb5e)
 - [Code a Taylor Swift Lyrics Generator](https://towardsdatascience.com/ai-generates-taylor-swifts-song-lyrics-6fd92a03ef7e)
-- [Mask detection using PyTorch Lightning](https://towardsdatascience.com/how-i-built-a-face-mask-detector-for-covid-19-using-pytorch-lightning-67eb3752fd61)
+- [Mask detection using PyTorch Lightning](https://web.archive.org/web/20211127115609/https://towardsdatascience.com/how-i-built-a-face-mask-detector-for-covid-19-using-pytorch-lightning-67eb3752fd61)
 
 ### Miscellaneous:
 


### PR DESCRIPTION
## Summary\n- replace the broken TowardsDataScience URL for `Mask detection using PyTorch Lightning`\n- use a stable Wayback snapshot so the project resource remains accessible\n\n## Validation\n- original URL returns 404\n- archived URL returns 200\n\nFixes #788