### PR TITLE
fix: replace broken Build a Reddit Bot link

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 
 ### Bots:
 
-- [Build a Reddit Bot](http://pythonforengineers.com/build-a-reddit-bot-part-1/)
+- [Build a Reddit Bot](https://praw.readthedocs.io/en/stable/tutorials/reply_bot.html)
 - [How to Make a Reddit Bot - YouTube](https://www.youtube.com/watch?v=krTUf7BpTc0) (video)
 - [Build a Facebook Messenger Bot](https://blog.hartleybrody.com/fb-messenger-bot/)
 - [Making a Reddit + Facebook Messenger Bot](https://pythontips.com/2017/04/13/making-a-reddit-facebook-messenger-bot/)


### PR DESCRIPTION
## Summary\n- update the broken `Build a Reddit Bot` URL in the Python section\n- point to the maintained PRAW reply bot tutorial\n\nCloses #761