### PR TITLE
docs: add resource type tagging guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,12 +7,19 @@ Before making a pull request, please make sure of the following:
 * The pull request needs to have a descriptive title
 * If the language/technology of your tutorial does not exist, feel free to create a new entry in table of contents
 * Make a separate pull request for each of the tutorial
-* Use the following format `[Title](link_to_tutorial)`
+* Use the following format `[Title](link_to_tutorial) [guide]`
+* Append exactly one resource tag at the end of each new tutorial entry: `[guide] [video] [course] [book] [repo]`
 * If your tutorial is a multi-part series, use the following format:
     ```
         * Title
             * [Part 1](link_to_part_1)
             * [Part 2](link_to_part_2)
+    ```
+* Valid single-entry examples:
+    ```
+        * [Build a REST API](https://example.com) [guide]
+        * [Build a Game Engine](https://example.com) [video]
+        * [Create a Compiler](https://example.com) [repo]
     ```
 * Check the spelling and grammar
 * Do the work, write good commit messages, and read the CONTRIBUTING file if there is one

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ A list of programming tutorials in which aspiring software developers learn how 
 
 To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 
+### Resource tags
+
+Use one tag at the end of each tutorial item to indicate its primary format:
+`[guide] [video] [course] [book] [repo]`
+
+Example:
+
+- [Tutorial Title](https://example.com) [guide]
+
+This rollout can start with new entries first and expand gradually across older lists.
+
 ## Table of Contents:
 
 - [C#](#c)
@@ -34,9 +45,9 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 
 ## C/C++:
 
-- [Build an Interpreter](http://www.craftinginterpreters.com/) (Chapter 14 on is written in C)
-- [Memory Allocators 101 - Write a simple memory allocator](https://arjunsreedharan.org/post/148675821737/memory-allocators-101-write-a-simple-memory)
-- [Write a Shell in C](https://brennan.io/2015/01/16/write-a-shell-in-c/)
+- [Build an Interpreter](http://www.craftinginterpreters.com/) [book] (Chapter 14 on is written in C)
+- [Memory Allocators 101 - Write a simple memory allocator](https://arjunsreedharan.org/post/148675821737/memory-allocators-101-write-a-simple-memory) [guide]
+- [Write a Shell in C](https://brennan.io/2015/01/16/write-a-shell-in-c/) [guide]
 - [Write a FUSE Filesystem](https://www.cs.nmsu.edu/~pfeiffer/fuse-tutorial/)
 - [Build Your Own Text Editor](http://viewsourcecode.org/snaptoken/kilo/)
 - [Build Your Own Lisp](http://www.buildyourownlisp.com/)


### PR DESCRIPTION
Closes #63

- add a small resource-tag legend to README
- document the one-tag rule in CONTRIBUTING
- demonstrate the format with a few pilot examples